### PR TITLE
Added ifdefs for SLUG variables and some explanation on SLUG_DIR in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ## workarounds for compiler and MPI bugs
 * Clang is the recommended compiler. Intel compiler version 2020.3.304 is tested and also works. (Earlier Intel versions sometimes fail to work correctly with SLUG and/or GIZMO.) GCC also mostly works (but do *not* use GCC version 7, it will generate incorrect code that will crash).
 * `NO_ISEND_IRECV_IN_DOMAIN` should *always* be enabled; otherwise the code will randomly hang in an MPI call during the domain decomposition
+* Disable FITS and MPI support while building SLUG. Use `make lib` instead of `make` because SLUG is only needed as a library
 * `USE_MPI_IN_PLACE` should *almost always* be enabled (required if using OpenMPI); if it is not but it should be, the code will crash during MPI calls with aliased pointers
 * *If you are using Mellanox Infiniband cards:* The Mellanox hardware-accelerated MPI collectives implementation has a bug that crashes the code. Workaround: add `-x HCOLL_ENABLE_MCAST=0` to the `mpirun` command-line options
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## workarounds for compiler and MPI bugs
 * Clang is the recommended compiler. Intel compiler version 2020.3.304 is tested and also works. (Earlier Intel versions sometimes fail to work correctly with SLUG and/or GIZMO.) GCC also mostly works (but do *not* use GCC version 7, it will generate incorrect code that will crash).
 * `NO_ISEND_IRECV_IN_DOMAIN` should *always* be enabled; otherwise the code will randomly hang in an MPI call during the domain decomposition
-* Disable FITS and MPI support while building SLUG. Use `make lib` instead of `make` because SLUG is only needed as a library
+* Disable FITS and MPI support while building SLUG. Use `make lib` instead of `make` because SLUG is only needed as a library. Before running GIZMO (e.g., using a `pbs` script), you have to explicitly set the environment variable `SLUG_DIR='/absolute/path/to/slug'` otherwise gizmo cannot locate slug.
 * `USE_MPI_IN_PLACE` should *almost always* be enabled (required if using OpenMPI); if it is not but it should be, the code will crash during MPI calls with aliased pointers
 * *If you are using Mellanox Infiniband cards:* The Mellanox hardware-accelerated MPI collectives implementation has a bug that crashes the code. Workaround: add `-x HCOLL_ENABLE_MCAST=0` to the `mpirun` command-line options
 

--- a/src/io.c
+++ b/src/io.c
@@ -806,15 +806,18 @@ void fill_write_buffer(enum iofields blocknr, int *startindex, int pc, int type)
             break;
         
         case IO_SLUG_STATE_INITIAL: /* It is a true/false entry, recording whether the slug cluster is turned on*/
+#ifdef SLUG
             for(n = 0; n < pc; pindex++)
                 if(P[pindex].Type == type)
                 {
                     *ip_int++ = (int) P[pindex].slug_state_initialized;
                     n++;
                 }
+#endif
             break;
         
         case IO_SLUG_STATE_RNG:  /* It is an 128 bit integer. I split it into 2 64 bit integers for easier output */
+#ifdef SLUG
             for(n = 0; n < pc; pindex++)
                 if(P[pindex].Type == type)
                 {   rng_state_t x;
@@ -825,9 +828,11 @@ void fill_write_buffer(enum iofields blocknr, int *startindex, int pc, int type)
                     *ip_int64++ = part2;
                     n++;
                 }
+#endif
             break;
 
         case IO_SLUG_STATE_INT:
+#ifdef SLUG
             for(n = 0; n < pc; pindex++)
                 if(P[pindex].Type == type)
                 {
@@ -835,9 +840,11 @@ void fill_write_buffer(enum iofields blocknr, int *startindex, int pc, int type)
                     *ip_int64++ = (uint64_t) P[pindex].slug_state.stoch_sn;
                     n++;
                 }
+#endif
             break;
 
         case IO_SLUG_STATE_DOUBLE: /*I did not include the last three quantities since I dont know how to deal with N */
+#ifdef SLUG
             for(n = 0; n < pc; pindex++)
                 if(P[pindex].Type == type)
                 {
@@ -866,6 +873,7 @@ void fill_write_buffer(enum iofields blocknr, int *startindex, int pc, int type)
                     *fp++ = (MyOutputFloat) P[pindex].slug_state.last_yield_time;
                     n++;
                 }
+#endif
             break;
 
         case IO_VGRADNORM: /* Velocity gradient */
@@ -1699,23 +1707,31 @@ int get_bytes_per_blockelement(enum iofields blocknr, int mode)
             break;
         
         case IO_SLUG_STATE_INITIAL:
+#ifdef SLUG
             bytes_per_blockelement = sizeof(int);
             //Total size of the struct
+#endif
             break;
 
         case IO_SLUG_STATE_RNG:
+#ifdef SLUG
             bytes_per_blockelement = sizeof(uint64_t) * 2;
             //Total size of the struct
+#endif
             break;
 
         case IO_SLUG_STATE_INT:
+#ifdef SLUG
             bytes_per_blockelement = sizeof(uint64_t) * 2;
             //Total size of the struct
+#endif
             break;
 
         case IO_SLUG_STATE_DOUBLE:
+#ifdef SLUG
             bytes_per_blockelement = sizeof(double) * 23;
             //Total size of the struct
+#endif
             break;
 
         case IO_AGE_PROTOSTAR:
@@ -1948,19 +1964,27 @@ int get_datatype_in_block(enum iofields blocknr)
             break;
         
         case IO_SLUG_STATE_INITIAL:
+#ifdef SLUG
             typekey = 0;		/* native int */
+#endif
             break;
 
         case IO_SLUG_STATE_RNG:
+#ifdef SLUG
             typekey = 2;		/* 64 bit int */
+#endif
             break;
 
         case IO_SLUG_STATE_INT:
+#ifdef SLUG
             typekey = 2;		/* 64 bit int */
+#endif
             break;
 
         case IO_SLUG_STATE_DOUBLE:
+#ifdef SLUG
             typekey = 1;		/* Double */
+#endif
             break;
 
         default:
@@ -1979,19 +2003,27 @@ int get_values_per_blockelement(enum iofields blocknr)
     switch (blocknr)
     {   
         case IO_SLUG_STATE_INITIAL:
+#ifdef SLUG
             values = 1;
+#endif
             break;
 
         case IO_SLUG_STATE_RNG:
+#ifdef SLUG
             values = 2;
+#endif
             break;
 
         case IO_SLUG_STATE_INT:
+#ifdef SLUG
             values = 2;
+#endif
             break;
         
         case IO_SLUG_STATE_DOUBLE:
+#ifdef SLUG
             values = 23;
+#endif
             break;
 
         case IO_POS:
@@ -2313,23 +2345,31 @@ long get_particles_in_block(enum iofields blocknr, int *typelist)
             break;
 
         case IO_SLUG_STATE_INITIAL:
+#ifdef SLUG
             for(i=0; i<6; i++) {if(i != 4) {typelist[i] = 0;}}
             return nstars_tot; /* only type 4 star particles will have SLUG properties */
+#endif
             break;
 
         case IO_SLUG_STATE_RNG:
+#ifdef SLUG
             for(i=0; i<6; i++) {if(i != 4) {typelist[i] = 0;}}
             return nstars_tot; /* only type 4 star particles will have SLUG properties */
+#endif
             break;
 
         case IO_SLUG_STATE_INT:
+#ifdef SLUG
             for(i=0; i<6; i++) {if(i != 4) {typelist[i] = 0;}} 
             return nstars_tot; /* only type 4 star particles will have SLUG properties */
+#endif
             break;
 
         case IO_SLUG_STATE_DOUBLE:
+#ifdef SLUG
             for(i=0; i<6; i++) {if(i != 4) {typelist[i] = 0;}}
             return nstars_tot; /* only type 4 star particles will have SLUG properties */
+#endif
             break;
 
         case IO_OSTAR:
@@ -2639,19 +2679,27 @@ int blockpresent(enum iofields blocknr)
             break;
         
         case IO_SLUG_STATE_INITIAL:
+#ifdef SLUG
             return 1;
+#endif
             break;
 
         case IO_SLUG_STATE_RNG:
+#ifdef SLUG
             return 1;
+#endif
             break;
         
         case IO_SLUG_STATE_INT:
+#ifdef SLUG
             return 1;
+#endif
             break;
 
         case IO_SLUG_STATE_DOUBLE:
+#ifdef SLUG
             return 1;
+#endif
             break;
 
         case IO_IMF:
@@ -3089,16 +3137,24 @@ void get_Tab_IO_Label(enum iofields blocknr, char *label)
             strncpy(label, "VGRA", 4);
             break;
         case IO_SLUG_STATE_INITIAL:
+#ifdef SLUG
             strncpy(label, "SITL", 4);
+#endif
             break;
         case IO_SLUG_STATE_RNG:
+#ifdef SLUG
             strncpy(label, "SRNG", 4);
+#endif
             break;
         case IO_SLUG_STATE_INT:
+#ifdef SLUG
             strncpy(label, "SINT", 4);
+#endif
             break; 
         case IO_SLUG_STATE_DOUBLE:
+#ifdef SLUG
             strncpy(label, "SDOU", 4);
+#endif
             break;        
         case IO_VORT:
             strncpy(label, "VORT", 4);
@@ -3478,16 +3534,24 @@ void get_dataset_name(enum iofields blocknr, char *buf)
             strcpy(buf, "NormVelocityGradient");
             break;
         case IO_SLUG_STATE_INITIAL:
+#ifdef SLUG
             strcpy(buf, "SlugStateInitial");
+#endif
             break;
         case IO_SLUG_STATE_RNG:
+#ifdef SLUG
             strcpy(buf, "SlugStateRng");
+#endif
             break; 
         case IO_SLUG_STATE_INT:
+#ifdef SLUG
             strcpy(buf, "SlugStateInt");
+#endif
             break; 
         case IO_SLUG_STATE_DOUBLE:
+#ifdef SLUG
             strcpy(buf, "SlugStateDouble");
+#endif
             break;      
         case IO_VORT:
             strcpy(buf, "Vorticity");

--- a/src/read_ic.c
+++ b/src/read_ic.c
@@ -507,28 +507,35 @@ void empty_read_buffer(enum iofields blocknr, int offset, int pc, int type)
 
         /* SLUG objects*/
         case IO_SLUG_STATE_INITIAL:  /* saving whether slug object is intialized */
+#ifdef SLUG
             for(n = 0; n < pc; n++) {
                 P[offset + n].slug_state_initialized = *ip_int++;
                 }
+#endif
             break;
 
         case IO_SLUG_STATE_RNG:  /* combining 2 64 bit int into one 128 int */
+#ifdef SLUG
             for(n = 0; n < pc; n++) {
                 uint64_t part1 = *ip_int64++;
                 rng_state_t part2 = *ip_int64++;
                 P[offset + n].slug_state.rngStateAtBirth = part1 + (part2 << 64);
                 }
+#endif
             break;
 
         case IO_SLUG_STATE_INT:
+#ifdef SLUG
             for(n = 0; n < pc; n++) 
                 {
                     P[offset + n].slug_state.id = *ip_int64++;
                     P[offset + n].slug_state.stoch_sn = *ip_int64++;
                 }
+#endif
             break;
 
         case IO_SLUG_STATE_DOUBLE: /*I did not include the last three quantities since I dont know how to deal with N */
+#ifdef SLUG
             for(n = 0; n < pc; n++) 
                 {
                     P[offset + n].slug_state.targetMass = *fp++;
@@ -555,6 +562,7 @@ void empty_read_buffer(enum iofields blocknr, int offset, int pc, int type)
                     P[offset + n].slug_state.tot_sn = *fp++;
                     P[offset + n].slug_state.last_yield_time = *fp++;
                 }
+#endif
             break;
 
         /* the other input fields (if present) are not needed to define the


### PR DESCRIPTION
@BenWibking  If I compile the code with SLUG not defined in `Config.sh`, I get errors from SLUG variables. To rectify this, I added ifdefs around all SLUG cases and variables in the IO and READ_IC files (similar to what GIZMO already has for CHIMES). I think Zipeng did not add these when he included SLUG in your gizmo-fork?

This is necessary if I want to use the exact same setup with and without SLUG and do simulations.

I also added a sentence in README on the necessity of setting the env variable SLUG_DIR before running gizmo.